### PR TITLE
Add the following features

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ it at `/app/scores` inside of the container.  Assuming you have a volume called
 `scores`:  
 
 ```
-docker run -d -v scores:/app/scores -p 8080:8000 scoresvr:0.1.0
+docker run -d -v scores:/app/scores scoresvr
+docker run -d -v scores:/var/www/html/scores -p 8080:8080 scoresvr-httpd
 ```
 
 ## Docker Compose
@@ -22,18 +23,13 @@ The compose file assumes that you have:
 1. A custom network called `scoresvr-net` created.  Alternatively, you could
    remove the `external` key and let Docker create it for you.
 
-Lastly, you may need to rebuild the `scoresvr-httpd` image.  Edit the file
-`web/scoresvr-httpd.conf` and uncomment the line:  
+To start the app:  
 
 ```
-ProxyPass "/" "http://scoreserver:8000/"
-```
-
-After that rebuild the image like so:  
-
-```
-cd web/
-docker build -t scoresvr-httpd .
+cd manifests/
+docker compose up
+# OR
+# docker compose up -d
 ```
 
 ## Kubernetes (minikube)
@@ -77,6 +73,7 @@ You have to load the images into the cluster with kind:
 
 ```
 kind load docker-image scoresvr
+kind load docker-image scoresvr-nginx
 ```
 
 ### Building the images for minikube
@@ -91,7 +88,7 @@ docker build -t <image_tag> .  # for example
 
 Then you can issue the `docker build` command however you like.
 
-## Deploying the app
+### Deploying the app
 
 ```
 kubectl create namespace scoreserver

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from flask import Flask, Blueprint, render_template, send_from_directory
+from flask import Flask, Blueprint, render_template, send_from_directory, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 SCORES_PATH = "scores"
@@ -22,8 +22,10 @@ def get_scores():
 def home():
     scores = get_scores()
 
-    return render_template("index.html", scores=scores)
+    return render_template("index.html", scores=scores, config=request.environ)
 
+# This shouldn't actually be doing anything in most cases.  It is just here to generate
+# URLs for the scores themselves.  There might be a better way to do this.
 @scoreserver.route("/scores/<title>")
 def send_score(title):
     return send_from_directory('scores', title)
@@ -31,4 +33,4 @@ def send_score(title):
 
 app = Flask(__name__)
 app.register_blueprint(scoreserver)
-app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1, x_prefix=1, x_for=1, x_proto=1)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1, x_prefix=1, x_for=2, x_proto=1)

--- a/app/main.py
+++ b/app/main.py
@@ -29,4 +29,4 @@ def send_score(title):
 
 
 app = Flask(__name__)
-app.register_blueprint(scoreserver, url_prefix="/scoreserver")
+app.register_blueprint(scoreserver)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from flask import Flask, Blueprint, render_template, send_from_directory
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 SCORES_PATH = "scores"
 scoreserver = Blueprint("scoreserver", __name__, template_folder="templates")
@@ -30,3 +31,4 @@ def send_score(title):
 
 app = Flask(__name__)
 app.register_blueprint(scoreserver)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1, x_prefix=1, x_for=1, x_proto=1)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,5 +11,10 @@
       <li><a href="{{ url_for('scoreserver.send_score', title=score ~ '.pdf') }}" target="_blank">{{ score }}</a></li>
       {% endfor %}
     </ul>
+    <h2>App Config</h2>
+    <ul>
+      {% for key, value in config.items() %}
+      <li>{{ key }}: {{ value }}</li>
+      {% endfor %}
   </body>
 </html>

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -3,12 +3,15 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: scoreserver-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
-  - http:
+  - host: scoreserver.info
+    http:
       paths:
       - pathType: Prefix
-        path: /
+        path: /scoreserver(/|$)(.*)
         backend:
           service:
             name: scoreserver-service

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -8,7 +8,7 @@ spec:
   - http:
       paths:
       - pathType: Prefix
-        path: /scoreserver
+        path: /
         backend:
           service:
             name: scoreserver-service

--- a/manifests/scoreserver.yaml
+++ b/manifests/scoreserver.yaml
@@ -24,6 +24,12 @@ spec:
           volumeMounts:
             - mountPath: "/app/scores"
               name: scores-mount
+        - image: scoresvr-nginx
+          name: scoresvr-nginx
+          imagePullPolicy: Never
+          volumeMounts:
+            - mountPath: "/opt/app-root/src/scores"
+              name: scores-mount
       volumes:
         - name: scores-mount
           hostPath:

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -8,4 +8,4 @@ spec:
     app: scoreserver
   ports:
     - port: 80 
-      targetPort: 8000
+      targetPort: 8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scoresvr"
-version = "0.1.0"
+version = "0.2.1"
 description = "Webapp to display musical scores"
 authors = ["Marc Patton <pattonmj8503@gmail.com>"]
 license = "MIT"

--- a/web/Dockerfile.nginx
+++ b/web/Dockerfile.nginx
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/nginx-122:1-59
+
+COPY scoresvr-nginx.conf /etc/nginx/nginx.conf
+
+CMD nginx -g "daemon off;"

--- a/web/scoresvr-httpd.conf
+++ b/web/scoresvr-httpd.conf
@@ -92,10 +92,7 @@ ServerAdmin root@localhost
 
 ProxyPreserveHost on
 
-RedirectMatch "^/$" "/scoreserver"
-
-ProxyPass "/scoreserver" "http://localhost:8000/scoreserver"
-#ProxyPass "/" "http://scoreserver:8000/"
+ProxyPass "/" "http://scoreserver:8000/"
 
 #
 # ServerName gives the name and port that the server uses to identify itself.

--- a/web/scoresvr-nginx.conf
+++ b/web/scoresvr-nginx.conf
@@ -1,0 +1,78 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+
+worker_processes auto;
+error_log /var/log/nginx/error.log notice;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /opt/app-root/src;
+
+        # Load configuration files for the default server block.
+        include /opt/app-root/etc/nginx.default.d/*.conf;
+
+        location /scores {
+        }
+            
+        location = /404.html {
+        }
+
+    }
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2;
+#        listen       [::]:443 ssl http2;
+#        server_name  _;
+#        root         /opt/app-root/src;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers PROFILE=SYSTEM;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /opt/app-root/etc/nginx.default.d/*.conf;
+#
+#        location = /404.html {
+#        }
+#
+#    }
+
+}
+

--- a/web/scoresvr-nginx.conf
+++ b/web/scoresvr-nginx.conf
@@ -50,6 +50,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded_Proto $scheme;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Prefix /scoreserver;
             proxy_redirect off;
             proxy_pass http://127.0.0.1:8000/;
         }

--- a/web/scoresvr-nginx.conf
+++ b/web/scoresvr-nginx.conf
@@ -43,7 +43,15 @@ http {
         # Load configuration files for the default server block.
         include /opt/app-root/etc/nginx.default.d/*.conf;
 
+        location /scores/ {
+        }
+
         location /scores {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded_Proto $scheme;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://127.0.0.1:8000/;
         }
             
         location = /404.html {

--- a/web/scoresvr-nginx.conf
+++ b/web/scoresvr-nginx.conf
@@ -46,10 +46,13 @@ http {
         location /scores/ {
         }
 
-        location /scores {
+        location / {
+            # Most of the X-Forwarded-* headers and handled by k8s ingress, so 
+            # there is no need to set them here.  The only one needed to be set 
+            # explicitly is X-Forwarded-Prefix.
+            #proxy_set_header X-Forwarded_Proto $scheme;
+            #proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded_Proto $scheme;
-            proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Prefix /scoreserver;
             proxy_redirect off;
             proxy_pass http://127.0.0.1:8000/;


### PR DESCRIPTION
* Use nginx for the Kubernetes deployment
* Use httpd for the Docker compose deployment
* Configure both web servers to serve the static files (i.e. the scores, which are PDFs)
* Configure ingress for the Kubernetes deployment
    * Use the `/scoreserver` prefix
    * Set the appropriate headers on the nginx reverse proxy and make the application aware of them